### PR TITLE
Run and read todo manager output

### DIFF
--- a/main_pc_code/config/startup_config.yaml
+++ b/main_pc_code/config/startup_config.yaml
@@ -132,6 +132,12 @@ agent_groups:
       required: true
       dependencies:
       - SystemDigitalTwin
+    CentralErrorBus:
+      script_path: services/central_error_bus/error_bus.py
+      port: "${PORT_OFFSET}+7150"
+      health_check_port: "${PORT_OFFSET}+8150"
+      required: true
+      dependencies: []
   memory_system:
     MemoryClient:
       script_path: main_pc_code/agents/memory_client.py
@@ -669,4 +675,8 @@ docker_groups:
     description: Cross-machine GPU load balancer
     agents:
       - CrossMachineGPUScheduler
+  error_bus:
+    description: Centralised error event bus
+    agents:
+      - CentralErrorBus
 # -----------------------------------------------------------------------------

--- a/pc2_code/config/startup_config.yaml
+++ b/pc2_code/config/startup_config.yaml
@@ -17,6 +17,16 @@ global_settings:
 
 # PC2 Services (Agents)
 pc2_services:
+  # Infrastructure Services
+  - {
+      name: CentralErrorBus,
+      script_path: services/central_error_bus/error_bus.py,
+      host: 0.0.0.0,
+      port: "${PORT_OFFSET}+7150",
+      health_check_port: "${PORT_OFFSET}+8150",
+      required: true,
+      dependencies: [],
+    }
   # Phase 1 - Integration Layer Agents
   - {
       name: MemoryOrchestratorService,
@@ -355,4 +365,8 @@ docker_groups:
     description: User-facing web interface agents
     agents:
       - UnifiedWebAgent
+  error_bus:
+    description: Centralised error event bus
+    agents:
+      - CentralErrorBus
 # -----------------------------------------------------------------------------

--- a/services/central_error_bus/Dockerfile
+++ b/services/central_error_bus/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.10-slim-bullseye
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt /tmp/
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+COPY . /app
+WORKDIR /app
+CMD ["python3", "error_bus.py"]

--- a/services/central_error_bus/README.md
+++ b/services/central_error_bus/README.md
@@ -1,0 +1,5 @@
+# Central Error Bus
+
+ZeroMQ-based PUB/SUB service that gathers structured error events from all
+agents (via IPC) and re-broadcasts them to any subscribers. Exposes Prometheus
+metrics on `9105/metrics`.

--- a/services/central_error_bus/error_bus.py
+++ b/services/central_error_bus/error_bus.py
@@ -1,0 +1,40 @@
+"""
+Central Error Bus
+-----------------
+• SUB socket (ipc:///tmp/agent_errors) – agents send JSON error events
+• PUB socket (tcp://*:7150)          – broadcasts to any subscribers
+• Prometheus counter at :9105/metrics
+"""
+import asyncio, json, os, signal, zmq, zmq.asyncio
+from prometheus_client import start_http_server, Counter
+
+PORT          = int(os.getenv("ERROR_BUS_PORT", "7150"))
+SUB_ENDPOINT  = os.getenv("SUB_ENDPOINT", "ipc:///tmp/agent_errors")
+PUB_ENDPOINT  = f"tcp://*:{PORT}"
+
+ERROR_CNT = Counter("error_events_total", "Error events", ["source"])
+
+ctx  = zmq.asyncio.Context()
+sub = ctx.socket(zmq.SUB); sub.bind(SUB_ENDPOINT); sub.setsockopt_string(zmq.SUBSCRIBE, "")
+pub = ctx.socket(zmq.PUB); pub.bind(PUB_ENDPOINT)
+
+async def forward():
+    while True:
+        raw = await sub.recv()
+        try:
+            msg = json.loads(raw)
+            ERROR_CNT.labels(msg.get("agent", "unknown")).inc()
+        except Exception:
+            msg = {"raw": raw.decode(errors="ignore")}
+            ERROR_CNT.labels("malformed").inc()
+        await pub.send_json(msg)
+
+def main() -> None:
+    start_http_server(9105)
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, loop.stop)
+    loop.add_signal_handler(signal.SIGTERM, loop.stop)
+    loop.run_until_complete(forward())
+
+if __name__ == "__main__":
+    main()

--- a/services/central_error_bus/requirements.txt
+++ b/services/central_error_bus/requirements.txt
@@ -1,0 +1,3 @@
+pyzmq>=25.1.2
+prometheus-client>=0.20.0
+uvloop>=0.19.0

--- a/tests/test_error_bus_import.py
+++ b/tests/test_error_bus_import.py
@@ -1,0 +1,3 @@
+def test_import():
+    import importlib
+    importlib.import_module("services.central_error_bus.error_bus")


### PR DESCRIPTION
# Description

This PR introduces a new Central Error Bus service to centralize error event collection and distribution across MainPC and PC2 systems.

The service:
- Receives structured error events from agents via ZeroMQ IPC (`ipc:///tmp/agent_errors`).
- Broadcasts these events via ZeroMQ TCP (`tcp://*:7150`) to subscribers.
- Exposes Prometheus metrics on port 9105 for error event tracking.

It includes the core `error_bus.py` service, a `Dockerfile` for containerization, and integration into both `main_pc_code/config/startup_config.yaml` and `pc2_code/config/startup_config.yaml` for seamless startup and dependency management.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Packaging Modernization

- [ ] I have NOT added any new `sys.path.insert` calls
- [ ] I have used proper imports (after installing with `pip install -e .`)
- [ ] I have reviewed the [package layout documentation](../MainPcDocs/SYSTEM_DOCUMENTATION/DEV_GUIDE/01_package_layout.md)

## Additional Notes

This implementation fulfills the task plan for establishing a Central Error Bus, enhancing system observability and providing a unified error handling mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0085a78-f9bc-4aaf-8232-1abeb3177b5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0085a78-f9bc-4aaf-8232-1abeb3177b5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

