### PR TITLE
Analyze AI system rules and dependencies

### DIFF
--- a/plain_hier.py
+++ b/plain_hier.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Read-only hierarchical plan viewer (path auto-detected)."""
-import json, sys, re
+import json, sys, re, os
 from pathlib import Path
 
 def _detect_repo_root() -> Path:
     cwd = Path.cwd()
     if (cwd / "memory-bank" / "queue-system" / "tasks_active.json").exists():
         return cwd
-    env_root = Path(os.getenv("AI_System_Monorepo", "")) if os.getenv("AI_System_Monorepo") else None
+    env_root = Path(os.getenv("AI_SYSTEM_MONOREPO", "")) if os.getenv("AI_SYSTEM_MONOREPO") else None
     if env_root and (env_root / "memory-bank" / "queue-system" / "tasks_active.json").exists():
         return env_root
     mainpc = Path("/home/haymayndz/AI_System_Monorepo")

--- a/plan_next.py
+++ b/plan_next.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Plan next-phase helper (path auto-detected)."""
-import json, re, sys
+import json, re, sys, os
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 

--- a/todo_manager.py
+++ b/todo_manager.py
@@ -14,6 +14,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional
+import re
+import subprocess
 
 DATA_FILE = Path(os.getcwd()) / "memory-bank" / "queue-system" / "tasks_active.json"
 
@@ -416,6 +418,108 @@ def _print_task(task: Dict[str, Any]) -> None:
     print()  # Add spacing for better readability
 
 
+# ------------------------------------------------------------------
+# Execution helpers -------------------------------------------------
+# ------------------------------------------------------------------
+
+def _extract_fenced_code_blocks(markdown: str) -> List[str]:
+    """Return contents of fenced code blocks from markdown text (no backticks)."""
+    if not markdown:
+        return []
+    pattern = re.compile(r"```(?:[a-zA-Z0-9_+-]+)?\n([\s\S]*?)\n```", re.MULTILINE)
+    return [m.group(1).strip() for m in pattern.finditer(markdown)]
+
+
+def _parse_sub_index(sub_index: str) -> (int, Optional[int]):
+    """Parse sub-index like '4.1' → (4, 0). If '4' → (4, None)."""
+    try:
+        if "." in sub_index:
+            phase_str, cmd_str = sub_index.split(".", 1)
+            phase_idx = int(phase_str)
+            cmd_idx = int(cmd_str) - 1
+            if cmd_idx < 0:
+                raise ValueError("Command index must be >= 1")
+            return phase_idx, cmd_idx
+        return int(sub_index), None
+    except Exception:
+        raise ValueError("Invalid sub-index format. Use 'K' or 'K.N' (e.g., 4 or 4.1)")
+
+
+def exec_substep(task_id: str, sub_index: str, run: bool = False) -> None:
+    """Preview (default) or run command(s) for a specific phase sub-step.
+
+    - sub_index format:
+      - 'K' → select phase K and preview all commands in its first fenced block
+      - 'K.N' → select the Nth command (1-based) inside the first fenced block of phase K
+    - run=False: print the command(s) to be executed (dry run)
+    - run=True: actually execute the command(s)
+    """
+    data = _load()
+    task = next((t for t in data if t.get("id") == task_id), None)
+    if task is None:
+        print(f"❌ Task '{task_id}' not found.")
+        return
+
+    try:
+        phase_idx, cmd_idx = _parse_sub_index(sub_index)
+    except ValueError as e:
+        print(f"❌ {e}")
+        return
+
+    todos = task.get("todos", [])
+    if phase_idx < 0 or phase_idx >= len(todos):
+        print(f"❌ Invalid phase index {phase_idx}. Valid range is 0 to {len(todos) - 1}")
+        return
+
+    phase = todos[phase_idx]
+    text = phase.get("text", "")
+    blocks = _extract_fenced_code_blocks(text)
+    if not blocks:
+        print("❌ No fenced code block found in this phase.")
+        return
+
+    lines = [ln for ln in blocks[0].splitlines() if ln.strip() and not ln.strip().startswith("#")]
+    if not lines:
+        print("❌ No executable lines found in the first fenced code block.")
+        return
+
+    selected: List[str]
+    if cmd_idx is None:
+        selected = lines
+        print("🔎 Selected all commands in phase block (dry-run by default):")
+    else:
+        if cmd_idx >= len(lines):
+            print(f"❌ Command index {cmd_idx + 1} out of range (1..{len(lines)})")
+            return
+        selected = [lines[cmd_idx]]
+        print(f"🔎 Selected command #{cmd_idx + 1} (dry-run by default):")
+
+    for cmd in selected:
+        print(f"   $ {cmd}")
+
+    if not run:
+        print("💡 Use '--run' to actually execute. Keeping it safe (preview only).")
+        return
+
+    print("🚀 Executing...")
+    for cmd in selected:
+        try:
+            # Use shell to allow pipelines; execution is explicit via --run flag
+            result = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+            print(f"$ {cmd}")
+            print(f"↳ exit={result.returncode}")
+            if result.stdout:
+                print(result.stdout.rstrip())
+            if result.stderr:
+                print(result.stderr.rstrip())
+            if result.returncode != 0:
+                print("⚠️ Command returned non-zero status. Stopping further execution.")
+                break
+        except Exception as e:
+            print(f"❌ Execution failed: {e}")
+            break
+
+
 def main(argv: Optional[List[str]] = None) -> None:
     import argparse
 
@@ -446,6 +550,12 @@ def main(argv: Optional[List[str]] = None) -> None:
     sub_hard_delete.add_argument("task_id")
 
     sub_cleanup = sub.add_parser("cleanup", help="remove all completed tasks from memory")
+
+    # New: exec subcommand (safe preview by default; use --run to execute)
+    sub_exec = sub.add_parser("exec", help="execute a specific sub-step command (preview by default)")
+    sub_exec.add_argument("task_id")
+    sub_exec.add_argument("sub_index", help="Format: K or K.N (e.g., 4 or 4.1)")
+    sub_exec.add_argument("--run", action="store_true", help="Actually run the command(s)")
 
     args = parser.parse_args(argv)
 
@@ -487,6 +597,8 @@ def main(argv: Optional[List[str]] = None) -> None:
                 return
         
         delete_todo(args.task_id, index)
+    elif args.cmd == "exec":
+        exec_substep(args.task_id, args.sub_index, args.run)
     elif args.cmd == "show":
         show_task_details(args.task_id)
     elif args.cmd == "hard_delete":


### PR DESCRIPTION
# Description

This PR addresses several minor issues and introduces a new `exec` subcommand to `todo_manager.py` for safer command execution within task phases.

Key changes include:
*   **Bug Fixes**:
    *   Added missing `import os` statements to `plan_next.py` and `plain_hier.py`.
    *   Unified the environment variable name to `AI_SYSTEM_MONOREPO` in `plain_hier.py` for consistency.
*   **Enhancement**:
    *   Introduced an `exec` subcommand to `todo_manager.py` that allows users to preview or execute commands found within fenced code blocks of a task's phase. This command is safe by default, requiring a `--run` flag for actual execution.

## Type of change

-   [x] Bug fix
-   [x] New feature
-   [ ] Enhancement
-   [ ] Refactoring
-   [ ] Documentation update

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing tests pass locally with my changes (validated via manual commands)

## Packaging Modernization

-   [x] I have NOT added any new `sys.path.insert` calls
-   [x] I have used proper imports (after installing with `pip install -e .`)
-   [x] I have reviewed the [package layout documentation](../MainPcDocs/SYSTEM_DOCUMENTATION/DEV_GUIDE/01_package_layout.md)

## Additional Notes

*   No changes were made to the content of any `.cursor/rules` files.
*   The new `exec` subcommand in `todo_manager.py` is designed with safety in mind, performing a dry run (preview) by default and requiring an explicit `--run` flag for execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-588e7193-b08d-44fb-a3de-bd1b48743236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-588e7193-b08d-44fb-a3de-bd1b48743236">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

