### PR TITLE
Analyze docker architecture and optimize

### DIFF
--- a/.github/workflows/build_families.yml
+++ b/.github/workflows/build_families.yml
@@ -1,0 +1,49 @@
+name: Build-and-Push Families
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "docker/**"
+      - ".github/workflows/build_families.yml"
+
+env:
+  REGISTRY: ghcr.io/${{ github.repository_owner }}
+  TAG: ${{ github.run_id }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        family:
+          - family-web
+          - family-torch-cu121
+          - family-vision-cu121
+          - family-llm-cu121
+          - base-cpu-pydeps
+          - legacy-py310-cpu
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & Push ${{ matrix.family }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/${{ matrix.family }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ matrix.family }}:${{ env.TAG }}
+          push: true
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/cache,mode=max


### PR DESCRIPTION
# Description

This PR introduces a new GitHub Actions workflow (`.github/workflows/build_families.yml`) to centralize the building and pushing of Docker family images to GitHub Container Registry (GHCR).

This workflow:
*   Uses a matrix strategy to build all defined base family images in parallel.
*   Leverages `docker buildx` with registry caching (`type=registry,ref=ghcr.io/<org>/cache`) for efficient and reproducible builds.
*   Tags images with `ghcr.io/<org>/<family>:${{ github.run_id }}` for unique and traceable versions.
*   Enables a "remote-build / local-pull" strategy, offloading image compilation from local machines to CI.

This change aims to improve build consistency, reduce local resource consumption, and streamline the image deployment process.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (this workflow serves as documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Packaging Modernization

- [ ] I have NOT added any new `sys.path.insert` calls
- [ ] I have used proper imports (after installing with `pip install -e .`)
- [ ] I have reviewed the [package layout documentation](../MainPcDocs/SYSTEM_DOCUMENTATION/DEV_GUIDE/01_package_layout.md)

## Additional Notes

The `REGISTRY` environment variable uses `ghcr.io/${{ github.repository_owner }}` to dynamically determine the organization's GHCR.
This workflow can be triggered manually via `workflow_dispatch` or automatically on pushes to `docker/**` or the workflow file itself.

---
<a href="https://cursor.com/background-agent?bcId=bc-72c97bd7-0e22-4a52-a23b-22a5b268db28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72c97bd7-0e22-4a52-a23b-22a5b268db28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

