### PR TITLE
Analyze claims and create remediation plan

### DIFF
--- a/memory-bank/DOCUMENTS/plan.md
+++ b/memory-bank/DOCUMENTS/plan.md
@@ -171,7 +171,6 @@ RemoteConnectorAgent	3060	CPU	base-cpu-pydeps	7124 / 8124
 UnifiedWebAgent	3060	CPU/Web	family-web	7126 / 8126
 DreamingModeAgent	3060	GPU/Vision	family-vision-cu121	7127 / 8127
 AdvancedRouter	3060	CPU	base-cpu-pydeps	7129 / 8129
-UnifiedObservabilityCenter (pc2)	3060	CPU/Web	family-web	9100 / 9110
 TutoringServiceAgent	3060	CPU	base-cpu-pydeps	7108 / 8108
 SpeechRelayService	3060	GPU/Audio	family-torch-cu121	7130 / 8130
 G. Risk Register & Rollback


### PR DESCRIPTION
# Description

Removed a duplicate entry for `UnifiedObservabilityCenter (pc2)` from the Fleet Coverage Table in `memory-bank/DOCUMENTS/plan.md`. This change aligns the documentation with the verified system state, where `UnifiedObservabilityCenter` is correctly listed once per machine in the `startup_config.yaml` files.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Packaging Modernization

- [ ] I have NOT added any new `sys.path.insert` calls
- [ ] I have used proper imports (after installing with `pip install -e .`)
- [ ] I have reviewed the [package layout documentation](../MainPcDocs/SYSTEM_DOCUMENTATION/DEV_GUIDE/01_package_layout.md)

## Additional Notes

This change addresses a specific inconsistency identified during the codebase audit, where `plan.md` contained a duplicate entry for `UnifiedObservabilityCenter` on PC2 that was not present in the actual `pc2_code/config/startup_config.yaml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e137f03-cd9a-4cc1-b556-a94ae551bcdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e137f03-cd9a-4cc1-b556-a94ae551bcdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

