### PR TITLE
Changes from background agent bc-86d4bcbd-05b1-4b28-bdb9-36d3a87036f4

### DIFF
--- a/predelete_preview.md
+++ b/predelete_preview.md
@@ -1,0 +1,24 @@
+Pre-Delete Preview — Hard Delete Candidates
+
+Input Status
+- hard_delete manifest: MISSING
+- evidence.json: MISSING
+
+Preview Rows
+- No entries to display. The expected columns per entry are listed for clarity:
+
+| Path | Score | Tests Passed | Tests Failed |
+|------|-------|--------------|--------------|
+| (none) | (n/a) | (n/a) | (n/a) |
+
+Notes
+- The repository scan did not reveal any hard_delete list. Without this manifest, a per-entry preview cannot be produced.
+- When a manifest is provided, this preview should enumerate each entry with:
+  - Path: absolute or repo-relative target path
+  - Score: numeric or categorical score used to prioritize deletion
+  - Tests Passed/Failed: derived from evidence.json for that path
+
+Operational Guardrails (Analysis-only)
+- No deletions were performed or proposed beyond listing structure.
+- Aligns with security/SRE policy: preview only; requires explicit approval and complete evidence before any action.
+

--- a/validation.md
+++ b/validation.md
@@ -1,0 +1,35 @@
+Validation Report — Hard Delete Review
+
+- Repo scan time: $(date is not embedded; see terminal logs for git state)
+
+Findings
+- hard_delete dataset: NOT FOUND (searched for files/keys matching: hard_delete, hard-delete, to_delete, delete_list)
+- evidence.json: NOT FOUND (searched patterns: evidence.json, evidence*.json)
+- keeplist.txt: NOT FOUND (searched patterns: keeplist.txt, keeplist*.txt)
+
+Requested Checks
+- Count of hard_delete entries with score < 5: 0
+  - Rationale: No hard_delete entries discovered in the repository; empty set implies count 0.
+
+- 10 random samples from hard_delete with their test results from evidence.json:
+  - N/A — No hard_delete dataset or evidence.json available. Samples cannot be produced.
+
+- Confirmation that keeplist.txt entries are preserved:
+  - Unknown — keeplist file not found during scan. Cannot verify preservation.
+
+Evidence of Search (high level)
+- Ran repository-wide searches for: evidence.json, keeplist.txt, hard_delete, hard-delete, to_delete, delete_list
+- Inspected task and cleanup areas under: /workspace, /workspace/memory-bank, /workspace/cleanup, tools/*
+- Found only function references to hard_delete_task in task tooling; no list/dataset of paths targeted for deletion was present.
+
+Recommended Next Steps (non-executing)
+- Provide the path(s) to the following inputs if they exist in another workspace or artifact store:
+  - The hard_delete manifest (JSON or text) with fields: path and score
+  - evidence.json containing per-path test results
+  - keeplist.txt enumerating files that must be preserved
+- Once available, re-run this validation to populate samples and preservation checks.
+
+Security/SRE Alignment
+- No filesystem modifications were executed.
+- This report is analysis-only and documents missing inputs and current zero-count outcome for < 5 scores.
+


### PR DESCRIPTION
# Description

This PR introduces `validation.md` and `predelete_preview.md` to document the pre-execution analysis for the KYC hardening task. These reports explicitly state the current absence of `hard_delete` manifests, `evidence.json`, and `keeplist.txt` within the repository, which are required inputs for a comprehensive pre-deletion review. This fulfills the analysis phase by clearly reporting the status of these critical artifacts.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Documentation update

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes

## Packaging Modernization

- [ ] I have NOT added any new `sys.path.insert` calls
- [ ] I have used proper imports (after installing with `pip install -e .`)
- [ ] I have reviewed the [package layout documentation](../MainPcDocs/SYSTEM_DOCUMENTATION/DEV_GUIDE/01_package_layout.md)

## Additional Notes

The generated reports confirm that no `hard_delete` entries were found, resulting in a count of 0 for entries with a score less than 5, and an empty pre-delete preview. The reports also note the inability to verify `keeplist.txt` preservation due to its absence.

---
<a href="https://cursor.com/background-agent?bcId=bc-86d4bcbd-05b1-4b28-bdb9-36d3a87036f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86d4bcbd-05b1-4b28-bdb9-36d3a87036f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

